### PR TITLE
improved automatic search of subtitles for video without metadata

### DIFF
--- a/service.py
+++ b/service.py
@@ -165,7 +165,7 @@ def normalizeString(str):
          ).encode('ascii','ignore')
 
 def parseSearchString(str):
-    res=re.findall('(.*?)s?0?(\d{1,3})x?e?0?(\d{1,3})', urllib.unquote(str), re.IGNORECASE)
+    res=re.findall('(.*\d*?) s?0?(\d{1,3})x?e?0?(\d{1,3})', urllib.unquote(str), re.IGNORECASE)
     item={}
     if res:
         item['tvshow']=res[0][0]


### PR DESCRIPTION
I've touched the lines below 219
`if item['title'] == "":`
to improve automatic search of subtitles whenever there is a video without correct metadata.
Using a regex the code parses the name of the file and gets: name of the show, episode and season.
Regex matches the most commons subtitles string forms like:
- Gotham S02E03
- Gotham 2x04  
- ecc  
