### PR TITLE
fixed manualsearch - added lower()

### DIFF
--- a/service.py
+++ b/service.py
@@ -242,7 +242,7 @@ if params['action'] == 'search':
   Search(item)
 
 elif params['action'] == 'manualsearch':
-    item = parseSearchString(params['searchstring'])
+    item = parseSearchString(params['searchstring'].lower())
     if item:
         langstring = urllib.unquote(params['languages']).decode('utf-8')
         item['3let_language'] = [xbmc.convertLanguage(lang,xbmc.ISO_639_2) for lang in langstring.split(",")]


### PR DESCRIPTION
Maybe there is a little bug, current regex doesn't match if user searches manually a string with capital "S" or "E" (for example: _The 100 **S**02**E**03_)
 now should be fixed! I hope it is the last one :smile:  
